### PR TITLE
Update iOS deployment target to 9.0 for Xcode 12

### DIFF
--- a/HTTPParserC.podspec
+++ b/HTTPParserC.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'HTTPParserC'
-  s.version = '2.9.2'
+  s.version = '2.10.0'
   s.license = 'MIT'
 
   s.summary = 'HTTP message parser written in C'
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { 'SWIFT_INCLUDE_PATHS' => '$(SRCROOT)/HTTPParserC/Sources/**' }
   s.requires_arc = false
 
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '9.0'
   s.watchos.deployment_target = '2.0'
   s.tvos.deployment_target = '9.0'
   s.osx.deployment_target = '10.6'

--- a/HTTPParserC.xcodeproj/project.pbxproj
+++ b/HTTPParserC.xcodeproj/project.pbxproj
@@ -166,7 +166,7 @@
 					"$(SRCROOT)/Sources/HTTPParserC/include",
 				);
 				INFOPLIST_FILE = HTTPParserC.xcodeproj/HTTPParserC_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MARKETING_VERSION = 2.9.2;
@@ -198,7 +198,7 @@
 					"$(SRCROOT)/Sources/HTTPParserC/include",
 				);
 				INFOPLIST_FILE = HTTPParserC.xcodeproj/HTTPParserC_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MARKETING_VERSION = 2.9.2;

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "HTTPParserC",
     platforms: [
-        .iOS(.v8),
+        .iOS(.v9),
         .tvOS(.v9),
         .macOS(.v10_10),
         .watchOS(.v2)


### PR DESCRIPTION
This was done to prevent Xcode 12 from throwing warnings (as iOS 8 is no longer supported by it).